### PR TITLE
Fixed reference to show_indent

### DIFF
--- a/pycot/__init__.py
+++ b/pycot/__init__.py
@@ -17,7 +17,7 @@ Python Cursor on Target Module.
 
 from .constants import LOG_LEVEL, LOG_FORMAT, BaseStrType  # NOQA
 
-from .utils import cast, showIndent  # NOQA
+from .utils import cast, show_indent  # NOQA
 
 from .functions import parse_event_type  # NOQA
 


### PR DESCRIPTION
I think you wanted to reference the show_indent you wrote, not the external library.  I changed this, and the code works on my box now.  It's cool to see someone else working on CoT in Python.